### PR TITLE
Mark version ranges as `true` values in stats script

### DIFF
--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -11,6 +11,9 @@ const checkSupport = (supportData, type) => {
   if (!Array.isArray(supportData)) {
     supportData = [supportData];
   }
+  if (type == "<=") {
+    return supportData.some(item => (typeof item.version_added == "string" && item.version_added.startsWith("<=")) || (typeof item.version_removed == "string" &&item.version_removed.startsWith("<=")));
+  }
   return supportData.some(item => item.version_added === type || item.version_removed === type)
 };
 
@@ -30,7 +33,7 @@ const processData = (data) => {
           stats.total.null++;
           real_value = false;
         }
-        if (checkSupport(data.support[browser], true)) {
+        if (checkSupport(data.support[browser], true) || checkSupport(data.support[browser], "<=")) {
           stats[browser].true++;
           stats.total.true++;
           real_value = false;


### PR DESCRIPTION
A follow-up addition to the PR on the master repository.  This will make sure the statistics script marks version ranges as `true` rather than `real` values.